### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This MCP plugin provides integration with the Alchemy SDK for blockchain and NFT operations.
 
+<a href="https://glama.ai/mcp/servers/p99w73336q">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/p99w73336q/badge" alt="Alchemy Plugin MCP server" />
+</a>
+
 ## Features
 
 - Get NFTs for a wallet address


### PR DESCRIPTION
This PR adds a badge for the [Alchemy MCP Plugin](https://glama.ai/mcp/servers/p99w73336q) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/p99w73336q">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/p99w73336q/badge" alt="Alchemy Plugin MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.